### PR TITLE
Use `package.include` to reduce the size of the packaged crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/awxkee/pxfm"
 rust-version = "1.85"
 categories = ["mathematics"]
 description = "Fast and accurate math"
+include = ["/src/", "/README.md", "/LICENSE.md", "/LICENSE-APACHE.md"]
 
 [dependencies]
 num-traits = "0.2"


### PR DESCRIPTION
I came across this crate during a dependency review (where it was pulled in via `image` → `moxcms` → `pxfm`, thought he `image` version is yanked at the moment it appears the dependency will get added back in soon enough), and noticed that as is, this crate packages the jupyter notebooks, which aren't used to actually build the final published package.  
This PR makes use of [`package.include`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields) to not package these files.

This reduces the uncompressed size from 4.7MiB to 3.4MiB (72%), and the compressed size from 1.2MiB to 836.3KiB (68.1%). Which might make sense especially if this does end up as a dependency for the `image` crate (via `moxcms`), as that likely will cause a lot of downloads.  
Additionally, it makes auditing easier too.