### PR TITLE
Remove num-traits dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,6 @@ categories = ["mathematics"]
 description = "Fast and accurate math"
 include = ["/src/", "/README.md", "/LICENSE.md", "/LICENSE-APACHE.md"]
 
-[dependencies]
-num-traits = "0.2.3"
-
 [profile.dev.package]
 bessel.opt-level = 3
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -26,8 +26,6 @@
  * // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-use num_traits::MulAdd;
-use std::ops::{Add, Mul};
 
 #[inline(always)]
 pub(crate) fn is_integerf(x: f32) -> bool {
@@ -148,38 +146,6 @@ pub(crate) fn is_odd_integer(x: f64) -> bool {
         const UNIT_EXPONENT: u64 = E_BIAS + 52;
         x_e + lsb as u64 == UNIT_EXPONENT
     }
-}
-
-#[cfg(any(
-    all(
-        any(target_arch = "x86", target_arch = "x86_64"),
-        target_feature = "fma"
-    ),
-    target_arch = "aarch64"
-))]
-#[inline(always)]
-pub(crate) fn mlaf<T: Copy + Mul<T, Output = T> + Add<T, Output = T> + MulAdd<T, Output = T>>(
-    acc: T,
-    a: T,
-    b: T,
-) -> T {
-    MulAdd::mul_add(a, b, acc)
-}
-
-#[inline(always)]
-#[cfg(not(any(
-    all(
-        any(target_arch = "x86", target_arch = "x86_64"),
-        target_feature = "fma"
-    ),
-    target_arch = "aarch64"
-)))]
-pub(crate) fn mlaf<T: Copy + Mul<T, Output = T> + Add<T, Output = T> + MulAdd<T, Output = T>>(
-    acc: T,
-    a: T,
-    b: T,
-) -> T {
-    acc + a * b
 }
 
 #[inline]
@@ -328,16 +294,6 @@ pub(crate) fn dd_fmlaf(a: f32, b: f32, c: f32) -> f32 {
     {
         (a as f64 * b as f64 + c as f64) as f32
     }
-}
-
-#[allow(dead_code)]
-#[inline(always)]
-pub(crate) fn c_mlaf<T: Copy + Mul<T, Output = T> + Add<T, Output = T> + MulAdd<T, Output = T>>(
-    a: T,
-    b: T,
-    c: T,
-) -> T {
-    mlaf(c, a, b)
 }
 
 /// Copies sign from `y` to `x`


### PR DESCRIPTION
This speeds up compile times by removing the dependency on the `num-traits` crate. At the moment `c_mlaf` isn't used anywhere so I just deleted it, but if it is needed in the future, the functionality could be added back by re-implementing `MulAdd` in this crate rather than using an external dependency for it.